### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,17 +15,10 @@ $ wstool merge https://raw.githubusercontent.com/personalrobotics/pr-rosinstalls
 
 ### Set up the udev rules ###
 
-Create a file called `/etc/udev/rules.d/45-jaco.rules` with the content:
+Create a file called `/etc/udev/rules.d/99-jaco.rules` with the content:
 
 ```
 SUBSYSTEM=="usb", ENV{DEVTYPE}=="usb_device", ATTR{idVendor} =="22cd", MODE="0666", GROUP="pr", SYMLINK+="mico"
-```
-### Set up Permission ###
-
-When running the robot for the first time, run the following command to setup the permission correctly:
-
-```
-sudo chmod 777 /dev/mico
 ```
 
 ### Running Ada ###

--- a/README.md
+++ b/README.md
@@ -20,8 +20,13 @@ Create a file called `/etc/udev/rules.d/45-jaco.rules` with the content:
 ```
 SUBSYSTEM=="usb", ENV{DEVTYPE}=="usb_device", ATTR{idVendor} =="22cd", MODE="0666", GROUP="pr", SYMLINK+="mico"
 ```
+### Set up Permission ###
 
-> A note on USB 3.0: the mico arm does not work with USB 3.0 ports. If your computer has no USB 2.0 ports, you will need to disable xHCI in your BIOS.
+When running the robot for the first time, run the following command to setup the permission correctly:
+
+```
+sudo chmod 777 /dev/mico
+```
 
 ### Running Ada ###
 You use ada in your script by simply calling the ``initialize`` function:


### PR DESCRIPTION
Remove the warning for USB3.0 as that does not matter any more
Add instructions on how to change the permission of the /dev/mico folder so the controller can be launched.