### PR TITLE
Update documentation to point to HARPLab

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ dependencies:
 ```shell
 $ wstool merge ~/harplab-rosinstalls/ada.rosinstall
 ```
+## Compilation ##
+Be sure you've run all the steps at https://github.com/HARPLab/harpdocs/blob/master/software\_machine\_setup.md in order to set up your machine with the required packages to compile this.
 
 ### Set up the udev rules ###
 

--- a/README.md
+++ b/README.md
@@ -4,13 +4,15 @@ Ada (or Assistive Dextrous Arm) is a package for controlling the Mico robot arm 
 ## Installation ##
 The following rosinstall can be used to get the minimum dependencies required
 to use AdaPy in simulation:
+
+First, be sure to clone https://github.com/HARPLab/harplab-rosinstalls.git into somewhere like ~/harplab-rosinstalls. If it's already there, make sure it's up to date. Then, run
 ```shell
-$ wstool merge https://raw.githubusercontent.com/personalrobotics/pr-rosinstalls/master/ada-sim.rosinstall
+$ wstool merge ~/harplab-rosinstalls/ada-sim.rosinstall 
 ```
 If you plan to connect to the real robot, then you will need a larger set of
 dependencies:
 ```shell
-$ wstool merge https://raw.githubusercontent.com/personalrobotics/pr-rosinstalls/master/ada.rosinstall
+$ wstool merge ~/harplab-rosinstalls/ada.rosinstall
 ```
 
 ### Set up the udev rules ###


### PR DESCRIPTION
Adding two minor changes to documentation for things I learned trying to set this up on my machine.

There's a stylistic change here as well, because HARPLab's rosinstall files are in a private github, and I don't think it's possible to wstool a private repo (another option would be to make the rosinstall repo public?). Or maybe I'm just wrong. As far as I can tell, you'd need to create a private github token in order to do this with wstool, which sounds more complicated than the method I used below.